### PR TITLE
Return a 404 for unknown API route

### DIFF
--- a/server/routes/api/index.js
+++ b/server/routes/api/index.js
@@ -7,4 +7,8 @@ router.use('/items', items);
 
 router.use('/users', users);
 
+router.use('*', (req, res, next) => {
+  res.status(404).json({errors: [{msg: 'Unknown API route'}]});
+});
+
 module.exports = router;


### PR DESCRIPTION
A tiny fix that returns a 404 for unknown API routes - it's placed in the API router so anything that's after `/api` that doesn't match whatever route we already defined for `/api` will ultimately end up here as the last route. Right now if you make a GET request to an `/api` route that doesn't exist, it would return the app webpage instead which doesn't make sense