### PR TITLE
Add validators for routes with object ids

### DIFF
--- a/server/middleware/shared/validators/isObjectId.js
+++ b/server/middleware/shared/validators/isObjectId.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+// eslint-disable-next-line valid-jsdoc
+/**
+ * @type {import('express-validator').CustomValidator}
+ */
+const isObjectId = async (value, {req}) => {
+  if (!mongoose.Types.ObjectId.isValid(value)) {
+    throw new Error('Malformed Object ID');
+  }
+  return true;
+};
+
+module.exports = isObjectId;

--- a/server/routes/api/items.js
+++ b/server/routes/api/items.js
@@ -5,6 +5,7 @@ const router = new express.Router();
 const {param} = require('express-validator');
 const itemController = require('../../controllers/items');
 const validatorErrors = require('../../middleware/shared/validatorErrors');
+const isObjectId = require('../../middleware/shared/validators/isObjectId');
 
 /**
  * @memberof module:api/items
@@ -23,7 +24,7 @@ router.get('/', itemController.getAll);
  * @name GET /:itemId
  */
 router.get('/:itemId', [
-  param('itemId').isAlphanumeric(),
+  param('itemId').custom(isObjectId),
   validatorErrors,
 ], itemController.get);
 
@@ -32,8 +33,8 @@ router.get('/:itemId', [
  * @name GET /rent
  */
 router.get('/:itemId/rent/:borrowerId/:duration', [
-  param('itemId').isAlphanumeric(),
-  param('borrowerId').isAlphanumeric(),
+  param('itemId').custom(isObjectId),
+  param('borrowerId').custom(isObjectId),
   param('duration').isInt(),
   validatorErrors,
 ], itemController.rent);

--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -4,7 +4,8 @@ const express = require('express');
 const router = new express.Router();
 const userController = require('../../controllers/users');
 const userMiddleware = require('../../middleware/users');
-const validationErrors = require('../../middleware/shared/validatorErrors');
+const validatorErrors = require('../../middleware/shared/validatorErrors');
+const validObjectId = require('../../middleware/shared/validators/isObjectId');
 const {check, param} = require('express-validator');
 
 /**
@@ -24,7 +25,7 @@ router.post('/register', [
   check('password')
       .isLength({min: 6}).withMessage('Password must be >6 characters')
       .custom(userMiddleware.expressValidator.matches),
-  validationErrors,
+  validatorErrors,
 ], userController.register);
 
 /**
@@ -41,21 +42,21 @@ router.post('/login', [
       .custom(userMiddleware.expressValidator.emailShouldExist(true)),
   check('password')
       .custom(userMiddleware.expressValidator.passwordMatchesHash),
-  validationErrors,
+  validatorErrors,
 ], userController.login);
 
 //
 router.get('/:userId', [
   param('userId', 'Invalid UserId')
-      .isAlphanumeric(),
-  validationErrors,
+      .custom(validObjectId),
+  validatorErrors,
 ], userController.get);
 
 
 router.patch('/:userId', [
-  param('userId', 'Invalid userID')
-      .isAlphanumeric(),
-  validationErrors,
+  param('userId')
+      .custom(validObjectId),
+  validatorErrors,
 ], userController.edit);
 /**
  *  @memberof module:api/users
@@ -63,7 +64,7 @@ router.patch('/:userId', [
  */
 router.get('/:userId/items', [
   param('userId', 'invalid UserId').isAlphanumeric(),
-  validationErrors,
+  validatorErrors,
 ], userController.getLendingList);
 
 


### PR DESCRIPTION
The server currently throws a 500 Internal Server Error if you pass an invalid mongoDB id to one of our routes that requires it - this will check before it reaches the error handler, and return a properly formed error