### PR TITLE
Add POST /api/users/:userId/items with auth

### DIFF
--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -1,4 +1,5 @@
 const userServices = require('../services/users');
+const itemServices = require('../services/items');
 
 // eslint-disable-next-line valid-jsdoc
 /** @type {import('express').RequestHandler} */
@@ -51,10 +52,32 @@ const getLendingList = async (req, res, next) => {
       .catch(next);
 };
 
+const createItem = async (req, res, next) => {
+  // This is attached in the users middleware "attachDecodedToken"
+  if (!req.jwtDecoded) {
+    return next(new Error('Decoded JWT payload not found'));
+  }
+  const {name, description} = req.body;
+  if (req.jwtDecoded.id !== req.params.userId) {
+    return res.status(401).json({
+      errors: [{msg: 'Unauthorized (non-matching IDs)'}],
+    });
+  }
+  const data = {
+    name,
+    description,
+    user: req.jwtDecoded.id,
+  };
+  itemServices.createItem(data)
+      .then((item) => res.json(item))
+      .catch(next);
+};
+
 module.exports = {
   login,
   register,
   get,
   edit,
   getLendingList,
+  createItem,
 };

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -1,7 +1,11 @@
 const userServices = require('../services/users');
 const itemServices = require('../services/items');
 
-/** @type {import('express').RequestHandler} */
+/**
+ * @typedef {import('express').RequestHandler} RequestHandler
+ */
+
+/** @type {RequestHandler} */
 const login = (req, res, next) => {
   const payload = {
     id: req.user.id,
@@ -13,7 +17,7 @@ const login = (req, res, next) => {
       .catch(next);
 };
 
-/** @type {import('express').RequestHandler} */
+/** @type {RequestHandler} */
 const register = async (req, res, next) => {
   const {name, email, password} = req.body;
   try {
@@ -26,14 +30,14 @@ const register = async (req, res, next) => {
   }
 };
 
-/** @type {import('express').RequestHandler} */
+/** @type {RequestHandler} */
 const get = (req, res, next) => {
   return userServices.findUser(req.params.userId)
       .then((user) => res.json(user))
       .catch(next);
 };
 
-/** @type {import('express').RequestHandler} */
+/** @type {RequestHandler} */
 const edit = (req, res, next) => {
   const name = req.body.name;
   const email = req.body.email;
@@ -42,7 +46,7 @@ const edit = (req, res, next) => {
       .catch(next);
 };
 
-/** @type {import('express').RequestHandler} */
+/** @type {RequestHandler} */
 const getLendingList = async (req, res, next) => {
   userServices.getLendingList(req.params.userId)
       .then((lendingList) => {
@@ -52,6 +56,7 @@ const getLendingList = async (req, res, next) => {
       .catch(next);
 };
 
+/** @type {RequestHandler} */
 const createItem = async (req, res, next) => {
   // This is attached in the users middleware "attachDecodedToken"
   if (!req.jwtDecoded) {

--- a/server/middleware/users.js
+++ b/server/middleware/users.js
@@ -2,6 +2,19 @@ const userServices = require('../services/users');
 const bcrypt = require('bcryptjs');
 
 const expressValidator = {
+  attachDecodedToken: async (value, {req}) => {
+    const splitted = value.split(' ');
+    if (splitted.length !== 2) {
+      throw new Error('Malformed authorization header');
+    }
+    if (splitted[0].toLowerCase() !== 'bearer') {
+      throw new Error('Incorrect authorization type (Must be Bearer)');
+    }
+    // This returns the same payload that userServices.getJwtToken accepts
+    const decoded = await userServices.verifyJwtToken(splitted[1]);
+    req.jwtDecoded = decoded;
+    return true;
+  },
   // eslint-disable-next-line valid-jsdoc
   /**
    * @param {boolean} shouldExist

--- a/server/middleware/users.js
+++ b/server/middleware/users.js
@@ -1,7 +1,12 @@
 const userServices = require('../services/users');
 const bcrypt = require('bcryptjs');
 
+/**
+ * @typedef {import('express-validator')} ExpressValidator
+ */
+
 const expressValidator = {
+  /** @type {ExpressValidator} */
   attachDecodedToken: async (value, {req}) => {
     const splitted = value.split(' ');
     if (splitted.length !== 2) {
@@ -15,12 +20,10 @@ const expressValidator = {
     req.jwtDecoded = decoded;
     return true;
   },
-  // eslint-disable-next-line valid-jsdoc
   /**
    * @param {boolean} shouldExist - Whether the validation should assert
    *     if the email exists, or if it does not exist
-   * @returns {import('express-validator').CustomValidator} - The
-   *     express-validator function
+   * @returns {ExpressValidator} - The express-validator function
    */
   emailShouldExist: (shouldExist) => async (value, {req}) => {
     const user = await userServices.findUserByEmail(value);
@@ -34,7 +37,7 @@ const expressValidator = {
     }
     return true;
   },
-  /** @type {import('express-validator').CustomValidator} */
+  /** @type {ExpressValidator} */
   passwordMatchesHash: async (value, {req}) => {
     // req.user is attached in emailShouldExist middleware
     const matched = await bcrypt.compare(value, req.user.password);
@@ -43,7 +46,7 @@ const expressValidator = {
     }
     return true;
   },
-  /** @type {import('express-validator').CustomValidator} */
+  /** @type {ExpressValidator} */
   matches: (value, {req}) => {
     if (value !== req.body.password2) {
       throw new Error('Passwords don\'t match');

--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -83,6 +83,12 @@ router.get('/:userId/items', [
   validatorErrors,
 ], userController.getLendingList);
 
+/**
+ * Create an item for a user
+ *
+ * @memberof module:api/users
+ * @name POST /:userId/items
+ */
 router.post('/:userId/items', [
   param('userId')
       .custom(validObjectId),

--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -63,13 +63,14 @@ router.patch('/:userId', [
  * @name GET /:userId/items
  */
 router.get('/:userId/items', [
-  param('userId', 'Invalid userId').isAlphanumeric(),
+  param('userId')
+      .custom(validObjectId),
   validatorErrors,
 ], userController.getLendingList);
 
 router.post('/:userId/items', [
-  param('userId', 'Invalid userId')
-      .isAlphanumeric(),
+  param('userId')
+      .custom(validObjectId),
   check('name')
       .isLength({min: 1}),
   check('description')

--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -6,7 +6,7 @@ const userController = require('../../controllers/users');
 const userMiddleware = require('../../middleware/users');
 const validatorErrors = require('../../middleware/shared/validatorErrors');
 const validObjectId = require('../../middleware/shared/validators/isObjectId');
-const {check, param} = require('express-validator');
+const {check, param, header} = require('express-validator');
 
 /**
  * Register user
@@ -63,9 +63,22 @@ router.patch('/:userId', [
  * @name GET /:userId/items
  */
 router.get('/:userId/items', [
-  param('userId', 'invalid UserId').isAlphanumeric(),
+  param('userId', 'Invalid userId').isAlphanumeric(),
   validatorErrors,
 ], userController.getLendingList);
 
+router.post('/:userId/items', [
+  param('userId', 'Invalid userId')
+      .isAlphanumeric(),
+  check('name')
+      .isLength({min: 1}),
+  check('description')
+      .isLength({min: 1}),
+  header('Authorization', 'Invalid Authorization header')
+      .isLength({min: 1})
+      .bail()
+      .custom(userMiddleware.expressValidator.attachDecodedToken),
+  validatorErrors,
+], userController.createItem);
 
 module.exports = router;

--- a/server/services/users.js
+++ b/server/services/users.js
@@ -23,6 +23,13 @@ const getJwtToken = (payload) => {
   });
 };
 
+/**
+ * Verify and decode a JWT token back to its original
+ * object.
+ *
+ * @param {string} token - The JWT token
+ * @returns {Promise<Object>} - The decoded object
+ */
 const verifyJwtToken = (token) => {
   return new Promise((resolve, reject) => {
     jwt.verify(token, keys.secretOrKey, (err, decoded) => {

--- a/server/services/users.js
+++ b/server/services/users.js
@@ -2,6 +2,8 @@ const bcrypt = require('bcryptjs');
 const keys = require('../config/keys');
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
+const mongoose = require('mongoose');
+const Item = require('../models/Item');
 const JWT_OPTIONS = {
   expiresIn: 31556926,
 };
@@ -13,8 +15,14 @@ const getJwtToken = (payload) => {
     });
   });
 };
-const mongoose = require('mongoose');
-const Item = require('../models/Item');
+
+const verifyJwtToken = (token) => {
+  return new Promise((resolve, reject) => {
+    jwt.verify(token, keys.secretOrKey, (err, decoded) => {
+      return err ? reject(err) : resolve(decoded);
+    });
+  });
+};
 
 const findUserByEmail = (email) => {
   return User.findOne({email});
@@ -61,4 +69,5 @@ module.exports = {
   findUser,
   editUser,
   getLendingList,
+  verifyJwtToken,
 };

--- a/server/services/users.unit.test.js
+++ b/server/services/users.unit.test.js
@@ -69,6 +69,22 @@ describe('Unit::services/users', function() {
       expect(userServices.getJwtToken()).rejects.toThrow(err);
     });
   });
+  describe('verifyJwtToken', function() {
+    it('resolves with decoded data', function() {
+      const resolved = 'etr43ouj';
+      jwt.verify.mockImplementationOnce((g1, g2, callback) => {
+        callback(null, resolved);
+      });
+      expect(userServices.verifyJwtToken()).resolves.toEqual(resolved);
+    });
+    it('rejects with the error', function() {
+      const error = new Error('aeqwt426r');
+      jwt.verify.mockImplementationOnce((g1, g2, callback) => {
+        callback(error);
+      });
+      expect(userServices.verifyJwtToken()).rejects.toThrow(error);
+    });
+  });
   describe('generateHash', function() {
     it('resolves with the token', async function() {
       const hash = 'wet4';


### PR DESCRIPTION
this route will allow a new item to be created for a certain user, with authentication, requiring incoming requests to have a [Authorization header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization) with the JWT token

I also made a tiny refactor in documenting - the repeated import doc line
```js
/** @type {import('express').RequestHandler} */
```
can be reduced to just
```js
/** @type {RequestHandler} */
```
if we include a `@typedef` at the top for `RequestHandler`

I made that mistake in some other files too like server/controllers/items in #105 , if you guys wanna _nudge nudge_ get some _nudge nudge_ documentation in _wink wink_