### PR TITLE
Add DELETE /api/users/:userId/items/:itemId with auth

### DIFF
--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -90,10 +90,10 @@ const deleteItem = async (req, res, next) => {
     });
   }
 
-  /** @type {import('mongoose').Document} */
+  /** @type {RequestHandler} */
   const item = req.item;
   if (item.get('user', String) !== userId) {
-    return res.status(401).json({
+    return res.status(404).json({
       errors: [{msg: 'Unauthorized (user does not own this item)'}],
     });
   };

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -73,6 +73,29 @@ const createItem = async (req, res, next) => {
       .catch(next);
 };
 
+const deleteItem = async (req, res, next) => {
+  const {userId, itemId} = req.params;
+
+  if (!req.jwtDecoded) {
+    return next(new Error('Decoded JWT payload not found'));
+  }
+  if (req.jwtDecoded.id !== userId) {
+    return res.status(401).json({
+      errors: [{msg: 'Unauthorized (non-matching IDs)'}],
+    });
+  }
+
+  /** @type {import('mongoose').Document} */
+  const item = req.item;
+  if (item.get('user', String) !== userId) {
+    return res.status(401).json({
+      errors: [{msg: 'Unauthorized (user does not own this item)'}],
+    });
+  };
+  await itemServices.deleteItem(itemId);
+  res.status(204).end();
+};
+
 module.exports = {
   login,
   register,
@@ -80,4 +103,5 @@ module.exports = {
   edit,
   getLendingList,
   createItem,
+  deleteItem,
 };

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -79,24 +79,7 @@ const createItem = async (req, res, next) => {
 };
 
 const deleteItem = async (req, res, next) => {
-  const {userId, itemId} = req.params;
-
-  if (!req.jwtDecoded) {
-    return next(new Error('Decoded JWT payload not found'));
-  }
-  if (req.jwtDecoded.id !== userId) {
-    return res.status(401).json({
-      errors: [{msg: 'Unauthorized (non-matching IDs)'}],
-    });
-  }
-
-  /** @type {RequestHandler} */
-  const item = req.item;
-  if (item.get('user', String) !== userId) {
-    return res.status(404).json({
-      errors: [{msg: 'Unauthorized (user does not own this item)'}],
-    });
-  };
+  const {itemId} = req.params;
   await itemServices.deleteItem(itemId);
   res.status(204).end();
 };

--- a/server/controllers/users.unit.test.js
+++ b/server/controllers/users.unit.test.js
@@ -126,30 +126,6 @@ describe('Unit::controller/users', function() {
     afterEach(function() {
       itemServices.deleteItem.mockReset();
     });
-    it('calls next(err) if decoded jwt payload not found', async function() {
-      const err = new Error('Decoded JWT payload not found');
-      const next = jest.fn();
-      await userController.deleteItem({params: {}}, {}, next);
-      expect(next).toHaveBeenCalledWith(err);
-    });
-    it('returns 401 if decoded id is not route :userId', async function() {
-      const userId = 'q135r';
-      const request = {params: {userId}};
-      const response = {status: jest.fn(() => ({json: jest.fn()}))};
-      request.jwtDecoded = {id: userId + 1};
-      await userController.deleteItem(request, response);
-      expect(response.status).toHaveBeenCalledWith(401);
-    });
-    it('returns 404 if item owner is not param userId', async function() {
-      const userId = '2q3rtgre';
-      const item = {get: () => userId + 1};
-      const request = {params: {userId}};
-      const response = {status: jest.fn(() => ({json: jest.fn()}))};
-      request.jwtDecoded = {id: userId};
-      request.item = item;
-      await userController.deleteItem(request, response);
-      expect(response.status).toHaveBeenCalledWith(404);
-    });
     it('returns 204 on success', async function() {
       const userId = '2q3rtgre';
       const item = {get: () => userId};

--- a/server/controllers/users.unit.test.js
+++ b/server/controllers/users.unit.test.js
@@ -122,4 +122,45 @@ describe('Unit::controller/users', function() {
           .toHaveBeenCalledWith(expectedItemCreation);
     });
   });
+  describe('deleteItem', function() {
+    afterEach(function() {
+      itemServices.deleteItem.mockReset();
+    });
+    it('calls next(err) if decoded jwt payload not found', async function() {
+      const err = new Error('Decoded JWT payload not found');
+      const next = jest.fn();
+      await userController.deleteItem({params: {}}, {}, next);
+      expect(next).toHaveBeenCalledWith(err);
+    });
+    it('returns 401 if decoded id is not route :userId', async function() {
+      const userId = 'q135r';
+      const request = {params: {userId}};
+      const response = {status: jest.fn(() => ({json: jest.fn()}))};
+      request.jwtDecoded = {id: userId + 1};
+      await userController.deleteItem(request, response);
+      expect(response.status).toHaveBeenCalledWith(401);
+    });
+    it('returns 404 if item owner is not param userId', async function() {
+      const userId = '2q3rtgre';
+      const item = {get: () => userId + 1};
+      const request = {params: {userId}};
+      const response = {status: jest.fn(() => ({json: jest.fn()}))};
+      request.jwtDecoded = {id: userId};
+      request.item = item;
+      await userController.deleteItem(request, response);
+      expect(response.status).toHaveBeenCalledWith(404);
+    });
+    it('returns 204 on success', async function() {
+      const userId = '2q3rtgre';
+      const item = {get: () => userId};
+      const request = {params: {userId}};
+      const endFunction = jest.fn();
+      const response = {status: jest.fn(() => ({end: endFunction}))};
+      request.jwtDecoded = {id: userId};
+      request.item = item;
+      await userController.deleteItem(request, response);
+      expect(response.status).toHaveBeenCalledWith(204);
+      expect(endFunction).toHaveBeenCalled();
+    });
+  });
 });

--- a/server/middleware/items.js
+++ b/server/middleware/items.js
@@ -1,0 +1,16 @@
+const itemServices = require('../services/items');
+
+const expressValidator = {
+  itemExistsAndAttach: async (value, {req}) => {
+    const item = await itemServices.findItem(value);
+    if (!item) {
+      throw new Error('Unknown item');
+    }
+    req.item = item;
+    return true;
+  },
+};
+
+module.exports = {
+  expressValidator,
+};

--- a/server/middleware/items.unit.test.js
+++ b/server/middleware/items.unit.test.js
@@ -1,0 +1,30 @@
+const itemMiddleware = require('./items');
+const itemServices = require('../services/items');
+
+jest.mock('../services/items');
+
+describe('Unit::middleware/items', function() {
+  describe('expressValidator', function() {
+    describe('itemExistsAndAttach', function() {
+      const {itemExistsAndAttach} = itemMiddleware.expressValidator;
+      it(`throws an error if item doesn't exist`, function() {
+        const error = new Error('Unknown item');
+        itemServices.findItem.mockResolvedValueOnce();
+        expect(itemExistsAndAttach('', {req: {}}))
+            .rejects.toThrowError(error);
+      });
+      it('returns true if found', function() {
+        itemServices.findItem.mockResolvedValueOnce({});
+        return expect(itemExistsAndAttach('', {req: {}}))
+            .resolves.toEqual(true);
+      });
+      it('attaches item document to request', async function() {
+        const request = {};
+        const item = {yo: 'mama so fat'};
+        itemServices.findItem.mockResolvedValueOnce(item);
+        await itemExistsAndAttach('', {req: request});
+        expect(request.item).toEqual(item);
+      });
+    });
+  });
+});

--- a/server/middleware/users.js
+++ b/server/middleware/users.js
@@ -60,21 +60,23 @@ const expressValidator = {
 };
 
 /** @type {ExpressHandler} */
-const userIsAuthorized = async (req, res, next) => {
+const userIsAuthorized = (req, res, next) => {
   if (req.jwtDecoded.id !== req.params.userId) {
-    res.status(401).json({
+    return res.status(401).json({
       errors: [{msg: 'Unauthorized (non-matching IDs)'}],
     });
   }
+  next();
 };
 
 /** @type {ExpressHandler} */
-const userOwnsItem = async (req, res, next) => {
+const userOwnsItem = (req, res, next) => {
   if (req.jwtDecoded.id !== req.item.get('user', String)) {
-    res.status(401).json({
+    return res.status(404).json({
       errors: [{msg: 'Unauthorized (does not own item)'}],
     });
   }
+  next();
 };
 
 module.exports = {

--- a/server/middleware/users.js
+++ b/server/middleware/users.js
@@ -2,7 +2,11 @@ const userServices = require('../services/users');
 const bcrypt = require('bcryptjs');
 
 /**
- * @typedef {import('express-validator')} ExpressValidator
+ * @typedef {import('express-validator').CustomValidator} ExpressValidator
+ */
+
+/**
+ * @typedef {import('express').RequestHandler} ExpressHandler
  */
 
 const expressValidator = {
@@ -55,6 +59,26 @@ const expressValidator = {
   },
 };
 
+/** @type {ExpressHandler} */
+const userIsAuthorized = async (req, res, next) => {
+  if (req.jwtDecoded.id !== req.params.userId) {
+    res.status(401).json({
+      errors: [{msg: 'Unauthorized (non-matching IDs)'}],
+    });
+  }
+};
+
+/** @type {ExpressHandler} */
+const userOwnsItem = async (req, res, next) => {
+  if (req.jwtDecoded.id !== req.item.get('user', String)) {
+    res.status(401).json({
+      errors: [{msg: 'Unauthorized (does not own item)'}],
+    });
+  }
+};
+
 module.exports = {
   expressValidator,
+  userIsAuthorized,
+  userOwnsItem,
 };

--- a/server/middleware/users.unit.test.js
+++ b/server/middleware/users.unit.test.js
@@ -6,6 +6,52 @@ jest.mock('../services/users');
 jest.mock('bcryptjs');
 
 describe('Unit::middleware/users', function() {
+  describe('userIsAuthorized', function() {
+    it('returns 401 if decoded id is not userId param', function() {
+      const userId = 'q135r';
+      const request = {
+        params: {userId},
+        jwtDecoded: {id: userId + 1},
+      };
+      const response = {status: jest.fn(() => ({json: jest.fn()}))};
+      usersMiddleware.userIsAuthorized(request, response);
+      expect(response.status).toHaveBeenCalledWith(401);
+    });
+    it('calls next on success', function() {
+      const userId = 'q135r';
+      const request = {params: {userId}};
+      const next = jest.fn();
+      request.jwtDecoded = {id: userId};
+      usersMiddleware.userIsAuthorized(request, {}, next);
+      expect(next).toHaveBeenCalledWith();
+    });
+  });
+  describe('userOwnsItem', function() {
+    it('returns 404 if item owner is not param userId', async function() {
+      const userId = '2q3rtgre';
+      const item = {get: () => userId + 1};
+      const request = {
+        params: {userId},
+        jwtDecoded: {id: userId},
+        item,
+      };
+      const response = {status: jest.fn(() => ({json: jest.fn()}))};
+      usersMiddleware.userOwnsItem(request, response);
+      expect(response.status).toHaveBeenCalledWith(404);
+    });
+    it('calls next on success', function() {
+      const userId = '2q3rtgre';
+      const item = {get: () => userId};
+      const request = {
+        params: {userId},
+        jwtDecoded: {id: userId},
+        item,
+      };
+      const next = jest.fn();
+      usersMiddleware.userOwnsItem(request, {}, next);
+      expect(next).toHaveBeenCalledWith();
+    });
+  });
   describe('expressValidator custom functions', function() {
     describe('attachDecodedToken', function() {
       afterEach(function() {

--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -115,6 +115,8 @@ router.delete('/:userId/items/:itemId', [
       .bail()
       .custom(userMiddleware.expressValidator.attachDecodedToken),
   validatorErrors,
+  userMiddleware.userIsAuthorized,
+  userMiddleware.userOwnsItem,
 ], userController.deleteItem);
 
 module.exports = router;

--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -4,6 +4,7 @@ const express = require('express');
 const router = new express.Router();
 const userController = require('../../controllers/users');
 const userMiddleware = require('../../middleware/users');
+const itemMiddleware = require('../../middleware/items');
 const validatorErrors = require('../../middleware/shared/validatorErrors');
 const validObjectId = require('../../middleware/shared/validators/isObjectId');
 const {check, param, header} = require('express-validator');
@@ -81,5 +82,18 @@ router.post('/:userId/items', [
       .custom(userMiddleware.expressValidator.attachDecodedToken),
   validatorErrors,
 ], userController.createItem);
+
+router.delete('/:userId/items/:itemId', [
+  param('userId')
+      .custom(validObjectId),
+  param('itemId')
+      .custom(validObjectId)
+      .custom(itemMiddleware.expressValidator.itemExistsAndAttach),
+  header('Authorization', 'Invalid Authorization header')
+      .isLength({min: 1})
+      .bail()
+      .custom(userMiddleware.expressValidator.attachDecodedToken),
+  validatorErrors,
+], userController.deleteItem);
 
 module.exports = router;

--- a/server/services/items.js
+++ b/server/services/items.js
@@ -6,6 +6,10 @@ const createItem = async (data) => {
   return item;
 };
 
+const deleteItem = async (id) => {
+  await Item.findByIdAndDelete(id);
+};
+
 const findItem = async (id) => {
   return await Item.findById(id);
 };
@@ -32,6 +36,7 @@ const endRent = async (id) => {
 
 module.exports = {
   createItem,
+  deleteItem,
   findItem,
   findAllItems,
   searchItems,

--- a/server/services/items.unit.test.js
+++ b/server/services/items.unit.test.js
@@ -21,6 +21,16 @@ describe('services/item', function() {
       expect(Item.mock.instances[0]).toEqual(returned);
     });
   });
+  describe('deleteItem', function() {
+    afterEach(function() {
+      Item.findByIdAndDelete.mockReset();
+    });
+    it('deletes the item', async function() {
+      const id = 'we23r4';
+      await itemServices.deleteItem(id);
+      expect(Item.findByIdAndDelete).toHaveBeenCalledWith(id);
+    });
+  });
   describe('findItem', function() {
     it('finds an item by id', async function() {
       const id = '12e';


### PR DESCRIPTION
this route will allow an item to be deleted, verified by authentication via JWT token provided in [Authorization](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization) header and item owner's user ID compared to the id in the decoded JWT token and the userId param

I also think sending errors back as arrays is a bit problematic for sending back API errors - lmk if you guys have any ideas