### PR TITLE
Fix user auth error displays and changed search

### DIFF
--- a/client/src/js/components/Login/Login.js
+++ b/client/src/js/components/Login/Login.js
@@ -63,12 +63,11 @@ export class Login extends Component {
 		const { errors } = this.state;
 		if (errors.errors === undefined || errors.errors.find(x => x.param === e) === undefined)
 		{
-			return true;
+			return "";
 		}
 		else
 		{
-			// return errors.errors.find(x => x.param === e).msg;
-			return false;
+			return errors.errors.find(x => x.param === e).msg;
 		}
 	};
 	render() {
@@ -83,7 +82,7 @@ export class Login extends Component {
 						<TextField
 							onChange={this.onChange}
 							value={this.state.email}
-							error={this.getErrors('email')}
+							error={this.getErrors('email')===""}
 							id="email"
 							type="email"
 							label="Email"
@@ -97,7 +96,7 @@ export class Login extends Component {
 						<TextField
 							onChange={this.onChange}
 							value={this.state.password}
-							error={this.getErrors('password')}
+							error={this.getErrors('password')===""}
 							id="password"
 							type="password"
 							label="Password"

--- a/client/src/js/components/Login/Login.js
+++ b/client/src/js/components/Login/Login.js
@@ -82,7 +82,8 @@ export class Login extends Component {
 						<TextField
 							onChange={this.onChange}
 							value={this.state.email}
-							error={this.getErrors('email')===""}
+							error={this.getErrors('email')!==""}
+							helperText={this.getErrors('email')}
 							id="email"
 							type="email"
 							label="Email"
@@ -91,12 +92,12 @@ export class Login extends Component {
                     			invalid: this.getErrors('email')
                   			})}
 						/>
-						<span>{this.getErrors('email')}</span>
 						<br/>
 						<TextField
 							onChange={this.onChange}
 							value={this.state.password}
-							error={this.getErrors('password')===""}
+							error={this.getErrors('password')!==""}
+							helperText={this.getErrors('password')}
 							id="password"
 							type="password"
 							label="Password"
@@ -105,7 +106,6 @@ export class Login extends Component {
                     			invalid: this.getErrors('password')
                   			})}
 						/>
-						<span>{this.getErrors('password')}</span>
 					<p>Dont have an account? <Link to="/register">Register</Link></p>
 					<div>
 					<Button 

--- a/client/src/js/components/Login/__snapshots__/Login.test.js.snap
+++ b/client/src/js/components/Login/__snapshots__/Login.test.js.snap
@@ -29,7 +29,7 @@ exports[`Login renders 1`] = `
       onSubmit={[Function]}
     >
       <div
-        className="MuiFormControl-root MuiTextField-root invalid MuiFormControl-fullWidth"
+        className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
       >
         <label
           className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-error Mui-error"
@@ -59,10 +59,12 @@ exports[`Login renders 1`] = `
           />
         </div>
       </div>
-      <span />
+      <span>
+        
+      </span>
       <br />
       <div
-        className="MuiFormControl-root MuiTextField-root invalid MuiFormControl-fullWidth"
+        className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
       >
         <label
           className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-error Mui-error"
@@ -92,7 +94,9 @@ exports[`Login renders 1`] = `
           />
         </div>
       </div>
-      <span />
+      <span>
+        
+      </span>
       <p>
         Dont have an account? 
         <a

--- a/client/src/js/components/Login/__snapshots__/Login.test.js.snap
+++ b/client/src/js/components/Login/__snapshots__/Login.test.js.snap
@@ -32,7 +32,7 @@ exports[`Login renders 1`] = `
         className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
       >
         <label
-          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-error Mui-error"
+          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
           data-shrink={false}
           htmlFor="email"
           id="email-label"
@@ -40,11 +40,11 @@ exports[`Login renders 1`] = `
           Email
         </label>
         <div
-          className="MuiInputBase-root MuiInput-root MuiInput-underline Mui-error Mui-error MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
           onClick={[Function]}
         >
           <input
-            aria-invalid={true}
+            aria-invalid={false}
             autoFocus={false}
             className="MuiInputBase-input MuiInput-input"
             disabled={false}
@@ -58,16 +58,14 @@ exports[`Login renders 1`] = `
             value=""
           />
         </div>
-      </div>
-      <span>
         
-      </span>
+      </div>
       <br />
       <div
         className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
       >
         <label
-          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-error Mui-error"
+          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
           data-shrink={false}
           htmlFor="password"
           id="password-label"
@@ -75,11 +73,11 @@ exports[`Login renders 1`] = `
           Password
         </label>
         <div
-          className="MuiInputBase-root MuiInput-root MuiInput-underline Mui-error Mui-error MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
           onClick={[Function]}
         >
           <input
-            aria-invalid={true}
+            aria-invalid={false}
             autoFocus={false}
             className="MuiInputBase-input MuiInput-input"
             disabled={false}
@@ -93,10 +91,8 @@ exports[`Login renders 1`] = `
             value=""
           />
         </div>
-      </div>
-      <span>
         
-      </span>
+      </div>
       <p>
         Dont have an account? 
         <a

--- a/client/src/js/components/Products/ProductList.js
+++ b/client/src/js/components/Products/ProductList.js
@@ -105,10 +105,10 @@ class ProductList extends Component {
               </IconButton>
             </ButtonGroup>
           </ListTop>
+          <Search resetPage={() => { this.setState({ page: 0 }) }} />
           <List>
             {items}
           </List>
-          <Search />
         </div>
       </div>
     )

--- a/client/src/js/components/Products/__snapshots__/ProductList.test.js.snap
+++ b/client/src/js/components/Products/__snapshots__/ProductList.test.js.snap
@@ -130,45 +130,92 @@ exports[`ProductList should render ProductList with given Redux state 1`] = `
         </button>
       </div>
     </div>
-    <ul
-      className="sc-EHOje fJblyY"
-    />
     <form
       noValidate={true}
       onSubmit={[Function]}
     >
       <div
-        className="MuiFormControl-root MuiTextField-root"
+        className="MuiBox-root MuiBox-root-95"
       >
-        <label
-          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
-          data-shrink={false}
-          htmlFor="query"
-          id="query-label"
-        >
-          Search Query
-        </label>
+        <span>
+          
+        </span>
         <div
-          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-          onClick={[Function]}
+          className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
         >
-          <input
-            aria-invalid={false}
-            autoFocus={false}
-            className="MuiInputBase-input MuiInput-input"
-            disabled={false}
-            id="query"
-            onAnimationStart={[Function]}
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            required={false}
-            type="text"
-            value=""
-          />
+          <label
+            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+            data-shrink={false}
+            htmlFor="query"
+            id="query-label"
+          >
+            Search Query
+          </label>
+          <div
+            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+            onClick={[Function]}
+          >
+            <input
+              aria-invalid={false}
+              autoFocus={false}
+              className="MuiInputBase-input MuiInput-input"
+              disabled={false}
+              id="query"
+              onAnimationStart={[Function]}
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              required={false}
+              type="text"
+              value=""
+            />
+          </div>
         </div>
+        <button
+          className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+          disabled={false}
+          id="search"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          style={
+            Object {
+              "borderRadius": 0,
+            }
+          }
+          tabIndex={0}
+          type="submit"
+        >
+          <span
+            className="MuiButton-label"
+          >
+            <svg
+              aria-hidden="true"
+              className="MuiSvgIcon-root"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+              />
+            </svg>
+          </span>
+        </button>
       </div>
     </form>
+    <ul
+      className="sc-EHOje fJblyY"
+    />
   </div>
 </div>
 `;

--- a/client/src/js/components/Register/Register.js
+++ b/client/src/js/components/Register/Register.js
@@ -64,12 +64,11 @@ export class Register extends Component {
 		const { errors } = this.state;
 		if(errors.errors === undefined || errors.errors.find(x => x.param === e) === undefined)
 		{
-			return true;
+			return "";
 		}
 		else
 		{
-			// return errors.errors.find(x => x.param === e).msg;
-			return false;
+			return errors.errors.find(x => x.param === e).msg;
 		}
 	};
 	render() {
@@ -86,7 +85,7 @@ export class Register extends Component {
 					<TextField
 						onChange={this.onChange}
 						value={this.state.name}
-						error={this.getErrors('name')}
+						error={this.getErrors('name')===""}
 						id="name"
 						label="Name"
 						type="text"
@@ -100,7 +99,7 @@ export class Register extends Component {
 					<TextField
 						onChange={this.onChange}
 						value={this.state.email}
-						error={this.getErrors('email')}
+						error={this.getErrors('email')===""}
 						id="email"
 						type="email"
 						label="Email"
@@ -114,7 +113,7 @@ export class Register extends Component {
 					<TextField
 						onChange={this.onChange}
 						value={this.state.password}
-						error={this.getErrors('password')}
+						error={this.getErrors('password')===""}
 						id="password"
 						type="password"
 						label="Password"
@@ -128,7 +127,7 @@ export class Register extends Component {
 					<TextField
 						onChange={this.onChange}
 						value={this.state.password2}
-						error={this.getErrors('password')}
+						error={this.getErrors('password')===""}
 						id="password2"
 						type="password"
 						label="Confirm Password"

--- a/client/src/js/components/Register/Register.js
+++ b/client/src/js/components/Register/Register.js
@@ -85,7 +85,8 @@ export class Register extends Component {
 					<TextField
 						onChange={this.onChange}
 						value={this.state.name}
-						error={this.getErrors('name')===""}
+						error={this.getErrors('name')!==""}
+						helperText={this.getErrors('name')}
 						id="name"
 						label="Name"
 						type="text"
@@ -94,12 +95,12 @@ export class Register extends Component {
 							invalid: this.getErrors('name')
 		                })}
 					/>
-					<span>{this.getErrors('name')}</span>
 					<br/>
 					<TextField
 						onChange={this.onChange}
 						value={this.state.email}
-						error={this.getErrors('email')===""}
+						error={this.getErrors('email')!==""}
+						helperText={this.getErrors('email')}
 						id="email"
 						type="email"
 						label="Email"
@@ -108,12 +109,12 @@ export class Register extends Component {
                     		invalid: this.getErrors('email')
                   		})}
 					/>
-					<span>{this.getErrors('email')}</span>
 					<br/>
 					<TextField
 						onChange={this.onChange}
 						value={this.state.password}
-						error={this.getErrors('password')===""}
+						error={this.getErrors('password')!==""}
+						helperText={this.getErrors('password')}
 						id="password"
 						type="password"
 						label="Password"
@@ -122,12 +123,12 @@ export class Register extends Component {
                     		invalid: this.getErrors('password')
                   		})}
 					/>
-					<span>{this.getErrors('password')}</span>
 					<br/>
 					<TextField
 						onChange={this.onChange}
 						value={this.state.password2}
-						error={this.getErrors('password')===""}
+						error={this.getErrors('password')!==""}
+						helperText={this.getErrors('password')}
 						id="password2"
 						type="password"
 						label="Confirm Password"

--- a/client/src/js/components/Register/__snapshots__/Register.test.js.snap
+++ b/client/src/js/components/Register/__snapshots__/Register.test.js.snap
@@ -32,7 +32,7 @@ exports[`Register renders 1`] = `
       onSubmit={[Function]}
     >
       <div
-        className="MuiFormControl-root MuiTextField-root invalid MuiFormControl-fullWidth"
+        className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
       >
         <label
           className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-error Mui-error"
@@ -62,10 +62,12 @@ exports[`Register renders 1`] = `
           />
         </div>
       </div>
-      <span />
+      <span>
+        
+      </span>
       <br />
       <div
-        className="MuiFormControl-root MuiTextField-root invalid MuiFormControl-fullWidth"
+        className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
       >
         <label
           className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-error Mui-error"
@@ -95,10 +97,12 @@ exports[`Register renders 1`] = `
           />
         </div>
       </div>
-      <span />
+      <span>
+        
+      </span>
       <br />
       <div
-        className="MuiFormControl-root MuiTextField-root invalid MuiFormControl-fullWidth"
+        className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
       >
         <label
           className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-error Mui-error"
@@ -128,10 +132,12 @@ exports[`Register renders 1`] = `
           />
         </div>
       </div>
-      <span />
+      <span>
+        
+      </span>
       <br />
       <div
-        className="MuiFormControl-root MuiTextField-root invalid MuiFormControl-fullWidth"
+        className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
       >
         <label
           className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-error Mui-error"

--- a/client/src/js/components/Register/__snapshots__/Register.test.js.snap
+++ b/client/src/js/components/Register/__snapshots__/Register.test.js.snap
@@ -35,7 +35,7 @@ exports[`Register renders 1`] = `
         className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
       >
         <label
-          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-error Mui-error"
+          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
           data-shrink={false}
           htmlFor="name"
           id="name-label"
@@ -43,11 +43,11 @@ exports[`Register renders 1`] = `
           Name
         </label>
         <div
-          className="MuiInputBase-root MuiInput-root MuiInput-underline Mui-error Mui-error MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
           onClick={[Function]}
         >
           <input
-            aria-invalid={true}
+            aria-invalid={false}
             autoFocus={false}
             className="MuiInputBase-input MuiInput-input"
             disabled={false}
@@ -61,16 +61,14 @@ exports[`Register renders 1`] = `
             value=""
           />
         </div>
-      </div>
-      <span>
         
-      </span>
+      </div>
       <br />
       <div
         className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
       >
         <label
-          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-error Mui-error"
+          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
           data-shrink={false}
           htmlFor="email"
           id="email-label"
@@ -78,11 +76,11 @@ exports[`Register renders 1`] = `
           Email
         </label>
         <div
-          className="MuiInputBase-root MuiInput-root MuiInput-underline Mui-error Mui-error MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
           onClick={[Function]}
         >
           <input
-            aria-invalid={true}
+            aria-invalid={false}
             autoFocus={false}
             className="MuiInputBase-input MuiInput-input"
             disabled={false}
@@ -96,16 +94,14 @@ exports[`Register renders 1`] = `
             value=""
           />
         </div>
-      </div>
-      <span>
         
-      </span>
+      </div>
       <br />
       <div
         className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
       >
         <label
-          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-error Mui-error"
+          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
           data-shrink={false}
           htmlFor="password"
           id="password-label"
@@ -113,11 +109,11 @@ exports[`Register renders 1`] = `
           Password
         </label>
         <div
-          className="MuiInputBase-root MuiInput-root MuiInput-underline Mui-error Mui-error MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
           onClick={[Function]}
         >
           <input
-            aria-invalid={true}
+            aria-invalid={false}
             autoFocus={false}
             className="MuiInputBase-input MuiInput-input"
             disabled={false}
@@ -131,16 +127,14 @@ exports[`Register renders 1`] = `
             value=""
           />
         </div>
-      </div>
-      <span>
         
-      </span>
+      </div>
       <br />
       <div
         className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
       >
         <label
-          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-error Mui-error"
+          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
           data-shrink={false}
           htmlFor="password2"
           id="password2-label"
@@ -148,11 +142,11 @@ exports[`Register renders 1`] = `
           Confirm Password
         </label>
         <div
-          className="MuiInputBase-root MuiInput-root MuiInput-underline Mui-error Mui-error MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
           onClick={[Function]}
         >
           <input
-            aria-invalid={true}
+            aria-invalid={false}
             autoFocus={false}
             className="MuiInputBase-input MuiInput-input"
             disabled={false}
@@ -166,6 +160,7 @@ exports[`Register renders 1`] = `
             value=""
           />
         </div>
+        
       </div>
       <br />
       <br />

--- a/client/src/js/components/Search/Search.js
+++ b/client/src/js/components/Search/Search.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { searchProducts } from '../../actions';
-import { TextField } from "@material-ui/core";
+import { Box, Button, TextField } from "@material-ui/core";
+import SearchIcon from '@material-ui/icons/Search';
 
 /**
  *	Search component that queries MongoDB database for items
@@ -12,7 +13,8 @@ export class Search extends React.Component {
 	{
 		super();
 		this.state = {
-			query : ""
+			query : "",
+			error : ""
 		};
 	}
 	/** 
@@ -25,25 +27,47 @@ export class Search extends React.Component {
 	}
 
 	/** 
-	 *	Call searchProducts action when submit event e is triggered
+	 *	Call searchProducts action when submit event e is triggered unless an invalid query is provided
 	 *	@param {event} e - submit event that submits form
 	 */
 	onSubmit = e =>
 	{
 		e.preventDefault();
-		this.props.searchProducts(".*"+this.state.query+".*");
+		if(this.state.query.length > 32)
+			this.setState({ error: "Too large of an input"})
+		else
+		{
+			this.props.searchProducts(".*"+this.state.query+".*");
+			this.setState({ error: ""})
+		}
 	}
 
 	render() {
 		return(
 			<form noValidate onSubmit={this.onSubmit}>
-				<TextField
-					onChange={this.onChange}
-					value={this.state.query}
-					id="query"
-					type="text"
-					label="Search Query"
-				/>
+				<Box display="flex">
+					<span>{this.state.error}</span>
+					<TextField
+						onChange={this.onChange}
+						value={this.state.query}
+						id="query"
+						type="text"
+						label="Search Query"
+						fullWidth
+					/>
+					<Button 
+						variant="contained"
+						color="primary" 
+						id="search"
+						type="submit" 
+						style={{borderRadius: 0 }}
+						onClick={() => {
+							this.props.resetPage()
+						}}
+					>
+	    			<SearchIcon />
+	  				</Button>
+  				</Box>
 			</form>
 			)
 	}

--- a/client/src/js/components/Search/Search.test.js
+++ b/client/src/js/components/Search/Search.test.js
@@ -18,8 +18,22 @@ describe('Search', () => {
 		expect(wrapper.state('query')).toEqual('chair');
 	});
 
+	test('invalid query entry', () => {
+		wrapper.find('#query').simulate('change', {target: {id: 'query', value: 'asdfghjklasdfghjklasdfghjklasdfghjklasdfghjkl'}});
+		wrapper.find('form').simulate('submit', {preventDefault() {}});
+		expect(wrapper.state('error')).toEqual('Too large of an input');
+	});
+
 	test('submit query', () => {
 		wrapper.find('form').simulate('submit', {preventDefault() {}});
 		expect(wrapper.instance().props.searchProducts).toHaveBeenCalled();
+	});
+
+	test('button click', () => {
+		const reset = jest.fn()
+		wrapper = shallow(<Search searchProducts = {searchProducts} resetPage={reset} />)
+		wrapper.find('#search').simulate('click');
+		expect(wrapper.instance().props.searchProducts).toHaveBeenCalled();
+		expect(wrapper.instance().props.resetPage).toHaveBeenCalled();
 	});
 })


### PR DESCRIPTION
Fixed error displaying on register and login. Due to changes of switching to material-ui, the TextField would require a boolean value for the errors field. Thus, the getErrors function had to be changed to return boolean values instead. Fix reverted to the original getErrors function and checked whether or not the corresponding error was empty (==="").

Changes to search:

- Moved search to be above the products and minor style changes
- Added a button to correspond to the search submit event
- Limited character entry for query to prevent bad requests
- Entering search query now redirects you to the first page of the products page. Prior to this, if you were on the 5th page and entered a query that would result in 1 item being displayed, you would still be on the 5th page with nothing shown until you manually navigated back to the 1st page through the pagination.