### PR TITLE
Ignore codecov patch in CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,6 +27,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }} #required
         flags: server
         name: codecov-server
+        yml: codecov.yml
 
   # Testing client
   test-client:
@@ -52,6 +53,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }} #required
         flags: client
         name: codecov-client
+        yml: codecov.yml
 
   # Linting server
   lint-server:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,7 @@
 coverage:
   status:
     project: true
-    patch: off
+    patch:
+      default:
+        enabled: no
+        if_not_found: success

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    project: true
+    patch: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,4 @@
 coverage:
   status:
     project: true
-    patch:
-      default:
-        enabled: no
-        if_not_found: success
+    patch: false


### PR DESCRIPTION
Codecov patch status in CI is unreliable - see https://github.com/CSC59939/QuikBorrow/pull/124 for an example, where it says only 75% of new changes are covered but no new changes were introduced other than tests. Having the project status should be good enough