### PR TITLE
Set item availability default to true

### DIFF
--- a/server/models/Item.js
+++ b/server/models/Item.js
@@ -5,7 +5,7 @@ const ItemSchema = new Schema({
   name: {type: String, default: ''},
   description: {type: String, default: ''},
   user: {type: Schema.Types.ObjectId, ref: 'User'},
-  availability: {type: Boolean, default: false},
+  availability: {type: Boolean, default: true},
   image: {type: Buffer},
   borrower: {type: Schema.Types.ObjectId},
   returnDate: {type: Date, default: Date.now},


### PR DESCRIPTION
Part of #112 

Right now when we add an item, it's unavailable by default for some reason so you can't immediately borrow it. This will fix that