### PR TITLE
Clear error states whenever route changes

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
     "@material-ui/lab": "^4.0.0-alpha.32",
     "axios": "^0.19.0",
     "classnames": "^2.2.6",
+    "history": "^4.10.1",
     "jwt-decode": "^2.2.0",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -10,6 +10,7 @@ import setAuthToken from "./js/utils/setAuthToken";
 import { setCurrentUser, logoutUser } from "./js/actions/index";
 import { Provider } from "react-redux";
 import reducers from "./js/reducers";
+import { BrowserRouter } from "react-router-dom";
 
 const store = createStore(reducers, {}, applyMiddleware(reduxThunk));
 
@@ -34,7 +35,9 @@ if (localStorage.jwtToken) {
 
 ReactDOM.render(
 	<Provider store={store}>
-    	<App />
+		<BrowserRouter>
+    		<App />
+		</BrowserRouter>
 	</Provider>,
   document.getElementById("root")
 );

--- a/client/src/js/actions/errors.js
+++ b/client/src/js/actions/errors.js
@@ -1,0 +1,8 @@
+import { CLEAR_ALL_ERRORS } from './types'
+
+/**
+ * Clears all error data in error state for all error types
+ */
+ export const clearAllErrors = () => {
+     return { type: CLEAR_ALL_ERRORS }
+ }

--- a/client/src/js/components/App.js
+++ b/client/src/js/components/App.js
@@ -1,5 +1,6 @@
-import React from "react";
-import { BrowserRouter, Route } from "react-router-dom";
+import React, { useEffect } from "react";
+import { Route, useHistory } from "react-router-dom";
+import { useDispatch } from 'react-redux'
 import "../../css/App.css";
 import 'typeface-roboto';
 import Homepage from "./Homepage/Homepage";
@@ -16,6 +17,7 @@ import styled from 'styled-components'
 import teal from '@material-ui/core/colors/teal'
 import cyan from '@material-ui/core/colors/cyan'
 import PageContent from './utils/PageContent'
+import { clearAllErrors } from '../actions/errors'
 
 const theme = createMuiTheme({
   palette: {
@@ -37,24 +39,30 @@ const Content = styled.div`
   padding-top: 60px;
 `
 
-function App() {
+export function App() {
+  const history = useHistory()
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    dispatch(clearAllErrors())
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ history.location.pathname ])
+
   return (
-      <BrowserRouter>
-        <ThemeProvider theme={theme}>
-          <Navbar />
-          <Content>
-            <Route exact path="/" component={Homepage} />
-            <PageContent>
-              <Route exact path="/register" component={Register} />
-              <Route exact path="/login" component={Login} />
-              <Route exact path="/products" component={ProductList} />
-              <Route exact path="/products/:productId" component={ProductDetail} />
-              <Route exact path="/dashboard" component={Dashboard} />
-              <Route exact path="/profile/:profileId" component={Profile} />
-            </PageContent>
-          </Content>
-          </ThemeProvider>
-      </BrowserRouter>
+    <ThemeProvider theme={theme}>
+      <Navbar />
+      <Content>
+        <Route exact path="/" component={Homepage} />
+        <PageContent>
+          <Route exact path="/register" component={Register} />
+          <Route exact path="/login" component={Login} />
+          <Route exact path="/products" component={ProductList} />
+          <Route exact path="/products/:productId" component={ProductDetail} />
+          <Route exact path="/dashboard" component={Dashboard} />
+          <Route exact path="/profile/:profileId" component={Profile} />
+        </PageContent>
+      </Content>
+      </ThemeProvider>
   );
 }
 

--- a/client/src/js/components/App.js
+++ b/client/src/js/components/App.js
@@ -43,6 +43,11 @@ export function App() {
   const history = useHistory()
   const dispatch = useDispatch()
 
+  /**
+   * The function in useEffect will run whenever history.location.pathname
+   * within the array in the second argument changes, which will dispatch
+   * an action to clear all errors whenever the page changes.
+   */
   useEffect(() => {
     dispatch(clearAllErrors())
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/src/js/components/App.test.js
+++ b/client/src/js/components/App.test.js
@@ -1,8 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './App.js';
+import FullApp, { App } from './App.js';
 import { Provider } from 'react-redux'
 import configureStore from 'redux-mock-store'
+import { BrowserRouter, Router } from 'react-router-dom'
+import Enzyme, { mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { createMemoryHistory } from 'history'
+import { clearAllErrors } from '../actions/errors'
+Enzyme.configure({ adapter: new Adapter() });
 const createStore = configureStore()
 
 it('renders without crashing', () => {
@@ -10,7 +16,24 @@ it('renders without crashing', () => {
   const store = createStore({auth: {user: {}}})
   ReactDOM.render(
     <Provider store={store}>
-      <App />
+      <BrowserRouter>
+        <FullApp />
+      </BrowserRouter>
     </Provider>, div);
   ReactDOM.unmountComponentAtNode(div);
 });
+
+it('clears all errors on path change', () => {
+  const history = createMemoryHistory()
+  const store = createStore({ auth: { user: {} } })
+  store.dispatch = jest.fn()
+  mount(
+    <Provider store={store}>
+      <Router history={history}>
+        <App />
+      </Router>
+    </Provider>
+  )
+  history.push('/someting')
+  expect(store.dispatch).toHaveBeenCalledWith(clearAllErrors())
+})

--- a/client/src/js/components/Login/Login.js
+++ b/client/src/js/components/Login/Login.js
@@ -27,8 +27,7 @@ export class Login extends Component {
 		super();
 		this.state = {
 			email: "",
-			password: "",
-			errors: {}
+			password: ""
 		};
 	}
 
@@ -41,11 +40,6 @@ export class Login extends Component {
 	componentWillReceiveProps(nextProps) {
     	if (nextProps.auth.isAuthenticated) {
       		this.props.history.push("/products"); // push user to dashboard when they login
-		}
-		if (nextProps.errors) {
-			this.setState({
-			  errors: nextProps.errors
-			});
 		}
   	}
 	onChange = e => {
@@ -60,8 +54,8 @@ export class Login extends Component {
 		this.props.loginUser(userData);
 	};
 	getErrors = e => {
-		const { errors } = this.state;
-		if (errors.errors === undefined || errors.errors.find(x => x.param === e) === undefined)
+		const { errors } = this.props;
+		if (!errors || errors.errors === undefined || errors.errors.find(x => x.param === e) === undefined)
 		{
 			return "";
 		}
@@ -127,7 +121,7 @@ export class Login extends Component {
 Login.propTypes = {
   loginUser: PropTypes.func.isRequired,
   auth: PropTypes.object.isRequired,
-  errors: PropTypes.object.isRequired
+  errors: PropTypes.object
 };
 
 const mapStateToProps = state => ({

--- a/client/src/js/components/Login/Login.test.js
+++ b/client/src/js/components/Login/Login.test.js
@@ -62,15 +62,4 @@ describe('Login', () => {
 		wrapper.setProps({ auth: { isAuthenticated: true } });
 		expect(historyMock.push.mock.calls[0]).toEqual(['/products']);
 	});
-
-	test('errors', () => {
-		const fakeErr = {
-			errors: [{
-				'param': 'email',
-				'msg' : 'Invalid email'
-			}]
-		}
-		wrapper.setProps({ errors: fakeErr });
-		expect(wrapper.state('errors')).toEqual(fakeErr);
-	});
 });

--- a/client/src/js/reducers/errorReducer.js
+++ b/client/src/js/reducers/errorReducer.js
@@ -25,7 +25,7 @@ export default function(state = initialState, action) {
     return state
   }
 
-  const stateKey = action.type.replace(/_ERROR|_FINISHED/g, '')
+  const stateKey = action.type
 
   /**
    * Remove the error object if this is a _FINISHED action
@@ -45,6 +45,6 @@ export default function(state = initialState, action) {
    * the ridiculous layers of information an Axios error
    * normally contains
    */
-  
-  return { ...state, [stateKey]: action.payload }
+
+   return { ...state, [stateKey]: action.payload }
 }

--- a/client/src/js/reducers/errorReducer.js
+++ b/client/src/js/reducers/errorReducer.js
@@ -46,5 +46,5 @@ export default function(state = initialState, action) {
    * normally contains
    */
 
-   return { ...state, [stateKey]: action.payload }
+  return { ...state, [stateKey]: action.payload }
 }

--- a/client/src/js/reducers/errorReducer.test.js
+++ b/client/src/js/reducers/errorReducer.test.js
@@ -19,18 +19,15 @@ describe('Error Reducer', () => {
 		const initialStateCopy = { ...initialState }
 		const payload = { foo: 'gosh darnit bobby' }
 		const action = { type: 'a_ERROR', payload }
-		const expectedStateKey = action.type.replace('_ERROR', '')
 		const returned = errorReducer(initialState, action)
-		expect(returned).toEqual({ ...initialState, [expectedStateKey]: action.payload })
+		expect(returned).toEqual({ ...initialState, [action.type]: action.payload })
 		// Assert that the reducer did not illegally mutate state
 		expect(initialState).toEqual(initialStateCopy)
 	})
 
 	it('removes the error from state if finished action', () => {
-		const stateKey = 'randomaction'
-		const actionType = stateKey + '_FINISHED'
-		const action = { type: actionType, payload: 1 }
-		const initialState = { jingle: 'bells', [stateKey]: 1 }
+		const action = { type: 'randomaction_FINISHED', payload: 1 }
+		const initialState = { jingle: 'bells', [action.type]: 1 }
 		const initialStateCopy = { ...initialState }
 		const returned = errorReducer(initialState, action)
 		expect(returned).toEqual({ jingle: 'bells' })

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2863,7 +2863,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2884,12 +2885,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2904,17 +2907,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3031,7 +3037,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3043,6 +3050,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3057,6 +3065,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3064,12 +3073,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3088,6 +3099,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3168,7 +3180,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3180,6 +3193,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3265,7 +3279,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3301,6 +3316,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3320,6 +3336,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3363,12 +3380,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
Part of #112 

this will clear errors whenever the browser history changes, so we no longer have to do what andy did that was to make sure the errors don't persist after changing pages:

https://github.com/CSC59939/QuikBorrow/blob/59fcb9218fbad07d62db9e75c9e4f7bc03f9300a/client/src/js/components/Login/Login.js#L41-L50

in line 45-49. so instead of accessing the error from state, we can now access the errors directly from the props now, since it's always empty when we first load a page. the magic happens in App.js:

https://github.com/CSC59939/QuikBorrow/blob/81c7091fbd6298d75332fedfacc05005a1f37bf3/client/src/js/components/App.js#L42-L54