### PR TITLE
Separate actions for users to own file

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -7,7 +7,7 @@ import { createStore, applyMiddleware } from "redux";
 import reduxThunk from "redux-thunk";
 import jwt_decode from "jwt-decode";
 import setAuthToken from "./js/utils/setAuthToken";
-import { setCurrentUser, logoutUser } from "./js/actions/index";
+import { setCurrentUser, logoutUser } from "./js/actions/users";
 import { Provider } from "react-redux";
 import reducers from "./js/reducers";
 import { BrowserRouter } from "react-router-dom";

--- a/client/src/js/actions/index.js
+++ b/client/src/js/actions/index.js
@@ -1,7 +1,5 @@
 import axios from "axios";
-import setAuthToken from "../utils/setAuthToken";
-import jwt_decode from "jwt-decode";
-import { FETCH_PRODUCTS, FETCH_PRODUCT, SET_CURRENT_USER, USER_LOADING, SEARCH_PRODUCTS, GET_USER, REGISTER_USER, LOGIN_USER } from "./types";
+import { FETCH_PRODUCTS, FETCH_PRODUCT, SEARCH_PRODUCTS, GET_USER } from "./types";
 export * from './products';
 
 // Fetch all products
@@ -43,68 +41,6 @@ export const searchProducts = query =>
           })
         });
   };
-
-// Register User
-export const registerUser = (userData, history) => dispatch => {
-  return axios
-    .post("/api/users/register", userData)
-    .then(res => history.push("/login")) // re-direct to login on successful register
-    .catch(err =>
-      dispatch({
-        type: REGISTER_USER.ERROR,
-        payload: err.response.data
-      })
-    );
-};
-
-// Login - get user token
-export const loginUser = userData => dispatch => {
-  return axios
-    .post("/api/users/login", userData)
-    .then(res => {
-      // Save to localStorage
-      // Set token to localStorage
-      const { token } = res.data;
-      localStorage.setItem("jwtToken", token);
-      // Set token to Auth header
-      setAuthToken(token);
-      // Decode token to get user data
-      const decoded = jwt_decode(token);
-      // Set current user
-      dispatch(setCurrentUser(decoded));
-    })
-    .catch(err =>
-      dispatch({
-        type: LOGIN_USER.ERROR,
-        payload: err.response.data
-      })
-    );
-};
-
-// Set logged in user
-export const setCurrentUser = decoded => {
-  return {
-    type: SET_CURRENT_USER,
-    payload: decoded
-  };
-};
-
-// User loading
-export const setUserLoading = () => {
-  return {
-    type: USER_LOADING
-  };
-};
-
-// Log user out
-export const logoutUser = () => dispatch => {
-  // Remove token from local storage
-  localStorage.removeItem("jwtToken");
-  // Remove auth header for future requests
-  setAuthToken(false);
-  // Set current user to empty object {} which will set isAuthenticated to false
-  dispatch(setCurrentUser({}));
-};
 
 export const getUserProfile = userId => {
   return async function(dispatch) {

--- a/client/src/js/actions/index.js
+++ b/client/src/js/actions/index.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { FETCH_PRODUCTS, FETCH_PRODUCT, SEARCH_PRODUCTS, GET_USER } from "./types";
+import { FETCH_PRODUCTS, FETCH_PRODUCT, SEARCH_PRODUCTS } from "./types";
 export * from './products';
 
 // Fetch all products
@@ -41,18 +41,3 @@ export const searchProducts = query =>
           })
         });
   };
-
-export const getUserProfile = userId => {
-  return async function(dispatch) {
-    try {
-    const res = await axios.get(`/api/users/${userId}`);
-    dispatch({ type: GET_USER.FINISHED, payload: res.data });
-  }
-  catch(error) {
-    console.log(error)
-    dispatch({
-      type: GET_USER.ERROR, payload: error
-      });
-    }
-  }
-};

--- a/client/src/js/actions/index.test.js
+++ b/client/src/js/actions/index.test.js
@@ -2,9 +2,7 @@ import axios from 'axios';
 import * as actions from './index';
 import { GET_USER, LOGIN_USER, SEARCH_PRODUCTS } from "./types";
 
-jest.mock('axios')
-jest.mock('../utils/setAuthToken')
-jest.mock('jwt-decode')
+jest.mock('axios');
 
 describe('actions', () => {
 	let mock;
@@ -38,61 +36,6 @@ describe('actions', () => {
 		    	payload: mockedError.response.data
 		  	});
 		});
-	});
-
-	test('registerUser', async () => {
-		const push = jest.fn();
-	    const history = { push };
-	    const dispatch = jest.fn();
-	    mock.mockResolvedValue();  // mock axios.post to resolve
-
-	    await actions.registerUser('user data', history)(dispatch);
-
-	    expect(mock).toHaveBeenCalledWith('/api/users/register', 'user data');  // Success!
-	    expect(history.push).toHaveBeenCalledWith('/login');
-	});
-
-	describe('loginUser', () => {
-	    const userData = {
-	    	email: 'test@test.com',
-	    	password: 'password'
-	    }
-		test('successful post made', async () => {
-			const dispatch = jest.fn();
-			mock.mockResolvedValue({data: {}});
-		    await actions.loginUser(userData)(dispatch);
-		    expect(mock).toHaveBeenCalledWith('/api/users/login', userData); 
-		});
-		test('error dispatched', async () => {
-			const dispatch = jest.fn();
-			const mockedError = {
-		    	response: {
-		        	data: 'test error'
-		      	}
-		    }
-		  	mock.mockRejectedValueOnce(mockedError);
-		  	await actions.loginUser(userData)(dispatch);
-		  	expect(dispatch).toHaveBeenCalledWith({
-		    	type: LOGIN_USER.ERROR,
-		    	payload: mockedError.response.data
-		  	});
-		});
-	});
-
-	test('setCurrentUser', () => {
-		const setUser = actions.setCurrentUser('decoded');
-		expect(setUser.payload).toEqual('decoded');
-	});
-
-	test('setUserLoading', () => {
-		const setUser = actions.setUserLoading();
-		expect(setUser.type).toEqual('USER_LOADING');
-	});
-
-	test('logoutUser', () => {
-		const dispatch = jest.fn();
-		actions.logoutUser()(dispatch);
-		expect(dispatch).toHaveBeenCalledWith({"payload": {}, "type": "SET_CURRENT_USER"});
 	});
 
 	describe('getUserProfile', () => {

--- a/client/src/js/actions/index.test.js
+++ b/client/src/js/actions/index.test.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import * as actions from './index';
-import { GET_USER, LOGIN_USER, SEARCH_PRODUCTS } from "./types";
+import { SEARCH_PRODUCTS } from "./types";
 
 jest.mock('axios');
 
@@ -34,48 +34,6 @@ describe('actions', () => {
 		  	expect(dispatch).toHaveBeenCalledWith({
 		    	type: SEARCH_PRODUCTS.ERROR,
 		    	payload: mockedError.response.data
-		  	});
-		});
-	});
-
-	describe('getUserProfile', () => {
-		const resp = {
-			data: {
-			rating: 0,
-			name: "test name",
-			email: "test1@test.com",
-			_id: "5dbb0cc7edeea12284986dcc"
-			}
-		}
-		test('Successful getUserProfile', async () => {
-			const dispatch = jest.fn();
-			let mock = axios.get.mockResolvedValue(resp)
-			await actions.getUserProfile(resp.data._id)(dispatch)
-			expect(mock).toHaveBeenCalledWith('/api/users/'+resp.data._id) //asserting what im testing in line 87
-			});
-
-		test('Successful dispatched', async () => {
-				const dispatch = jest.fn();
-				axios.get.mockResolvedValue(resp)
-				await actions.getUserProfile(resp)(dispatch)
-				expect(dispatch).toHaveBeenCalledWith({
-					type: GET_USER.FINISHED,
-					payload: resp.data
-					});
-				});
-
-		test('error dispatched', async () => {
-			const dispatch = jest.fn();
-			const mock_error = {
-					data: 'test error',
-					type: LOGIN_USER.ERROR,
-		      	}
-			  //axios.get.mockRejectedValue(resp);
-			axios.get.mockRejectedValueOnce(mock_error);
-		  	await actions.getUserProfile(mock_error)(dispatch);
-		  	expect(dispatch).toHaveBeenCalledWith({
-		    	type: GET_USER.ERROR,
-		    	payload: mock_error
 		  	});
 		});
 	});

--- a/client/src/js/actions/users.js
+++ b/client/src/js/actions/users.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import setAuthToken from "../utils/setAuthToken";
 import jwt_decode from "jwt-decode";
-import { SET_CURRENT_USER, USER_LOADING, REGISTER_USER, LOGIN_USER } from "./types";
+import { SET_CURRENT_USER, USER_LOADING, REGISTER_USER, LOGIN_USER, GET_USER } from "./types";
 
 /**
  * @typedef {import('redux').Dispatch} DispatchFunction
@@ -84,4 +84,24 @@ export const logoutUser = () => dispatch => {
   setAuthToken(false);
   // Set current user to empty object {} which will set isAuthenticated to false
   dispatch(setCurrentUser({}));
+};
+
+/**
+ *	Get user profile
+ *	@param {Object} userId - get profile based on userId
+ *	@returns {DispatchFunction}
+ */
+export const getUserProfile = userId => {
+  return async function(dispatch) {
+    try {
+    const res = await axios.get(`/api/users/${userId}`);
+    dispatch({ type: GET_USER.FINISHED, payload: res.data });
+  }
+  catch(error) {
+    console.log(error)
+    dispatch({
+      type: GET_USER.ERROR, payload: error
+      });
+    }
+  }
 };

--- a/client/src/js/actions/users.js
+++ b/client/src/js/actions/users.js
@@ -1,0 +1,87 @@
+import axios from "axios";
+import setAuthToken from "../utils/setAuthToken";
+import jwt_decode from "jwt-decode";
+import { SET_CURRENT_USER, USER_LOADING, REGISTER_USER, LOGIN_USER } from "./types";
+
+/**
+ * @typedef {import('redux').Dispatch} DispatchFunction
+ */
+
+/**
+ *	Register user 
+ *	@param {Object} userData - User credentials to create an account
+ *	@param {Object} history - used to navigate to different pages
+ *	@returns {DispatchFunction}
+ */
+export const registerUser = (userData, history) => dispatch => {
+  return axios
+    .post("/api/users/register", userData)
+    .then(res => history.push("/login")) // re-direct to login on successful register
+    .catch(err =>
+      dispatch({
+        type: REGISTER_USER.ERROR,
+        payload: err.response.data
+      })
+    );
+};
+
+/**
+ *	Login user 
+ *	@param {Object} userData - User credentials to login
+ *	@returns {DispatchFunction}
+ */
+export const loginUser = userData => dispatch => {
+  return axios
+    .post("/api/users/login", userData)
+    .then(res => {
+      const { token } = res.data;
+      localStorage.setItem("jwtToken", token);
+      // Set token to Auth header
+      setAuthToken(token);
+      // Decode token to get user data
+      const decoded = jwt_decode(token);
+      // Set current user
+      dispatch(setCurrentUser(decoded));
+    })
+    .catch(err =>
+      dispatch({
+        type: LOGIN_USER.ERROR,
+        payload: err.response.data
+      })
+    );
+};
+
+/**
+ *	Set current user
+ *	@param {Object} decoded - decoded jwtToken containing user info
+ *	@returns {Object}
+ */
+export const setCurrentUser = decoded => {
+  return {
+    type: SET_CURRENT_USER,
+    payload: decoded
+  };
+};
+
+/**
+ *	Set user loading
+ *	@returns {Object}
+ */
+export const setUserLoading = () => {
+  return {
+    type: USER_LOADING
+  };
+};
+
+/**
+ *	Logout user by removing auth token and saved info in storage
+ *	@returns {DispatchFunction}
+ */
+export const logoutUser = () => dispatch => {
+  // Remove token from local storage
+  localStorage.removeItem("jwtToken");
+  // Remove auth header for future requests
+  setAuthToken(false);
+  // Set current user to empty object {} which will set isAuthenticated to false
+  dispatch(setCurrentUser({}));
+};

--- a/client/src/js/actions/users.test.js
+++ b/client/src/js/actions/users.test.js
@@ -1,0 +1,90 @@
+import axios from 'axios';
+import * as actions from './users';
+import { REGISTER_USER, LOGIN_USER } from "./types";
+
+jest.mock('axios');
+jest.mock('../utils/setAuthToken');
+jest.mock('jwt-decode');
+
+describe('actions', () => {
+	let mock;
+	beforeEach(() => {
+		mock = jest.spyOn(axios, 'post');
+	});
+	afterEach(() => {
+		mock.mockRestore();
+	});
+	describe('registerUser', () => {
+		test('registerUser', async () => {
+			const push = jest.fn();
+		    const history = { push };
+		    const dispatch = jest.fn();
+		    mock.mockResolvedValue();  // mock axios.post to resolve
+
+		    await actions.registerUser('user data', history)(dispatch);
+
+		    expect(mock).toHaveBeenCalledWith('/api/users/register', 'user data');  // Success!
+		    expect(history.push).toHaveBeenCalledWith('/login');
+		});
+
+		test('error dispatched', async () => {
+			const push = jest.fn();
+		    const history = { push };
+			const dispatch = jest.fn();
+			const mockedError = {
+		    	response: {
+		        	data: 'test error'
+		      	}
+		    }
+		  	mock.mockRejectedValueOnce(mockedError);
+		  	await actions.registerUser('user data', history)(dispatch);
+		  	expect(dispatch).toHaveBeenCalledWith({
+		    	type: REGISTER_USER.ERROR,
+		    	payload: mockedError.response.data
+		  	});
+		});
+	});
+
+	describe('loginUser', () => {
+	    const userData = {
+	    	email: 'test@test.com',
+	    	password: 'password'
+	    }
+		test('successful post made', async () => {
+			const dispatch = jest.fn();
+			mock.mockResolvedValue({data: {}});
+		    await actions.loginUser(userData)(dispatch);
+		    expect(mock).toHaveBeenCalledWith('/api/users/login', userData); 
+		});
+		test('error dispatched', async () => {
+			const dispatch = jest.fn();
+			const mockedError = {
+		    	response: {
+		        	data: 'test error'
+		      	}
+		    }
+		  	mock.mockRejectedValueOnce(mockedError);
+		  	await actions.loginUser(userData)(dispatch);
+		  	expect(dispatch).toHaveBeenCalledWith({
+		    	type: LOGIN_USER.ERROR,
+		    	payload: mockedError.response.data
+		  	});
+		});
+	});
+
+	test('setCurrentUser', () => {
+		const setUser = actions.setCurrentUser('decoded');
+		expect(setUser.payload).toEqual('decoded');
+	});
+
+	test('setUserLoading', () => {
+		const setUser = actions.setUserLoading();
+		expect(setUser.type).toEqual('USER_LOADING');
+	});
+
+	test('logoutUser', () => {
+		const dispatch = jest.fn();
+		actions.logoutUser()(dispatch);
+		expect(dispatch).toHaveBeenCalledWith({"payload": {}, "type": "SET_CURRENT_USER"});
+	});
+});

--- a/client/src/js/actions/users.test.js
+++ b/client/src/js/actions/users.test.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import * as actions from './users';
-import { REGISTER_USER, LOGIN_USER } from "./types";
+import { GET_USER, REGISTER_USER, LOGIN_USER } from "./types";
 
 jest.mock('axios');
 jest.mock('../utils/setAuthToken');
@@ -86,5 +86,47 @@ describe('actions', () => {
 		const dispatch = jest.fn();
 		actions.logoutUser()(dispatch);
 		expect(dispatch).toHaveBeenCalledWith({"payload": {}, "type": "SET_CURRENT_USER"});
+	});
+
+	describe('getUserProfile', () => {
+		const resp = {
+			data: {
+			rating: 0,
+			name: "test name",
+			email: "test1@test.com",
+			_id: "5dbb0cc7edeea12284986dcc"
+			}
+		}
+		test('Successful getUserProfile', async () => {
+			const dispatch = jest.fn();
+			let mock = axios.get.mockResolvedValue(resp)
+			await actions.getUserProfile(resp.data._id)(dispatch)
+			expect(mock).toHaveBeenCalledWith('/api/users/'+resp.data._id) //asserting what im testing in line 87
+		});
+
+		test('Successful dispatched', async () => {
+			const dispatch = jest.fn();
+			axios.get.mockResolvedValue(resp)
+			await actions.getUserProfile(resp)(dispatch)
+			expect(dispatch).toHaveBeenCalledWith({
+				type: GET_USER.FINISHED,
+				payload: resp.data
+			});
+		});
+
+		test('error dispatched', async () => {
+			const dispatch = jest.fn();
+			const mock_error = {
+				data: 'test error',
+				type: LOGIN_USER.ERROR,
+	      	}
+			//axios.get.mockRejectedValue(resp);
+			axios.get.mockRejectedValueOnce(mock_error);
+		  	await actions.getUserProfile(mock_error)(dispatch);
+		  	expect(dispatch).toHaveBeenCalledWith({
+		    	type: GET_USER.ERROR,
+		    	payload: mock_error
+		  	});
+		});
 	});
 });

--- a/client/src/js/components/Dashboard/Dashboard.js
+++ b/client/src/js/components/Dashboard/Dashboard.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { logoutUser } from "../../actions/index";
+import { logoutUser } from "../../actions/users";
 
 export class Dashboard extends Component {
   componentDidMount () {

--- a/client/src/js/components/Dashboard/Dashboard.test.js
+++ b/client/src/js/components/Dashboard/Dashboard.test.js
@@ -4,10 +4,10 @@ import { MemoryRouter } from 'react-router-dom';
 import Enzyme, { shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { Dashboard } from './Dashboard';
-import { logoutUser } from "../../actions/index";
+import { logoutUser } from "../../actions/users";
 
 Enzyme.configure({ adapter: new Adapter() });
-jest.mock('../../actions/index');
+jest.mock('../../actions/users');
 
 describe('Dashboard', () => {
 	const params = {

--- a/client/src/js/components/Login/Login.js
+++ b/client/src/js/components/Login/Login.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { loginUser } from "../../actions/index";
+import { loginUser } from "../../actions/users";
 import classnames from "classnames";
 import styled from 'styled-components';
 import quikLogo from '../../components/quikLogo.png';

--- a/client/src/js/components/Login/Login.test.js
+++ b/client/src/js/components/Login/Login.test.js
@@ -4,10 +4,10 @@ import { MemoryRouter } from 'react-router-dom';
 import Enzyme, { shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { Login } from './Login';
-import { loginUser } from "../../actions/index";
+import { loginUser } from "../../actions/users";
 
 Enzyme.configure({ adapter: new Adapter() });
-jest.mock('../../actions/index');
+jest.mock('../../actions/users');
 
 describe('Login', () => {
 	const params = {

--- a/client/src/js/components/Navbar/SignedIn.js
+++ b/client/src/js/components/Navbar/SignedIn.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { logoutUser } from '../../actions';
+import { logoutUser } from '../../actions/users';
 import { Toolbar, Avatar } from '@material-ui/core';
 import styled from 'styled-components'
 

--- a/client/src/js/components/Profile/Profile.js
+++ b/client/src/js/components/Profile/Profile.js
@@ -1,7 +1,8 @@
 import React, { Component } from "react";
 import ProfileCard from './ProfileCard'
 import { connect } from "react-redux";
-import { getUserProfile, fetchProducts } from "../../actions";
+import { fetchProducts } from "../../actions";
+import { getUserProfile } from "../../actions/users";
 
 export class UserProfile extends Component {
     constructor(props) {

--- a/client/src/js/components/Register/Register.js
+++ b/client/src/js/components/Register/Register.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { Link, withRouter } from "react-router-dom";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { registerUser } from "../../actions/index";
+import { registerUser } from "../../actions/users";
 import classnames from "classnames";
 import styled from 'styled-components';
 import { Button, TextField } from '@material-ui/core';

--- a/client/src/js/components/Register/Register.test.js
+++ b/client/src/js/components/Register/Register.test.js
@@ -4,10 +4,10 @@ import { MemoryRouter } from 'react-router-dom';
 import Enzyme, { shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { Register } from './Register';
-import { registerUser } from "../../actions/index";
+import { registerUser } from "../../actions/users";
 
 Enzyme.configure({ adapter: new Adapter() });
-jest.mock('../../actions/index');
+jest.mock('../../actions/users');
 
 describe('Register', () => {
 	const params = {


### PR DESCRIPTION
As pointed out in https://github.com/CSC59939/QuikBorrow/pull/118, the index.js file for actions was getting cluttered with various actions focused on different components. 
This pr moves the `registerUser, loginUser, setCurrentUser, setUserLoading, and logoutUser` actions to its own users.js file. 
All imports that used any of these actions have been adjusted accordingly. 
I wasn't sure if the getUserProfile should go with it since these actions were mostly for user authentication. 