### PR TITLE
Separate client and server for codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,8 @@
 coverage:
   status:
-    project: true
+    project:
+      client:
+        flags: client
+      server:
+        flags: server
     patch: false


### PR DESCRIPTION
I think this is better for our CI process where we can see the separate coverage of the server/client since they're two separate projects, but lmk what you guys think

(this is for a better presentation too lol)

![image](https://user-images.githubusercontent.com/18688793/70589207-269f2200-1b9d-11ea-8a0f-fbf50adea784.png)
