### PR TITLE
Allow get transactions to return all of one user's transactions

### DIFF
--- a/server/middleware/transactions.js
+++ b/server/middleware/transactions.js
@@ -5,15 +5,15 @@
 const expressValidator = {
   /** @type {ExpressValidator} */
   validUserType: (value, {req}) => {
-    if (value !== 'borrower' && value !== 'lender') {
-      throw new Error('User type must be "borrower" or "lender"');
+    if (value && value !== 'borrower' && value !== 'lender') {
+      throw new Error('User type must be "borrower" or "lender" if it exists');
     }
     return true;
   },
   /** @type {ExpressValidator} */
   validProcessedType: (value, {req}) => {
-    if (value !== 'true' && value !== 'false') {
-      throw new Error('Porcessed query must be "true" or "false"');
+    if (value && value !== 'true' && value !== 'false') {
+      throw new Error('Processed query must be "true" or "false" if it exists');
     }
     return true;
   },

--- a/server/middleware/transactions.unit.test.js
+++ b/server/middleware/transactions.unit.test.js
@@ -9,6 +9,12 @@ describe('Unit://middleware/transactions', function() {
         expect(func('borrower', data)).toEqual(true);
         expect(func('lender', data)).toEqual(true);
       });
+      it('returns true for no value specified', function() {
+        const data = {req: {}};
+        const func = transactionsMiddleware.expressValidator.validUserType;
+        expect(func('', data)).toEqual(true);
+        expect(func('', data)).toEqual(true);
+      });
       it('throws an error for non-borrower and non-lender', function() {
         const data = {req: {}};
         const func = transactionsMiddleware.expressValidator.validUserType;
@@ -21,6 +27,12 @@ describe('Unit://middleware/transactions', function() {
         const func = transactionsMiddleware.expressValidator.validProcessedType;
         expect(func('true', data)).toEqual(true);
         expect(func('false', data)).toEqual(true);
+      });
+      it('returns true for no value specified', function() {
+        const data = {req: {}};
+        const func = transactionsMiddleware.expressValidator.validProcessedType;
+        expect(func('', data)).toEqual(true);
+        expect(func('', data)).toEqual(true);
       });
       it('throws an error for non-borrower and non-lender', function() {
         const data = {req: {}};

--- a/server/services/transactions.js
+++ b/server/services/transactions.js
@@ -57,17 +57,24 @@ const rejectTransaction = async (id) => {
  *
  * @param {string} userId - The id for the user
  * @param {string} type - The type between borrower or lender
- * @param {boolean} isProcessed - Processed filter for transactions
+ * @param {string} isProcessed - Processed filter for transactions
  * @returns {MongooseDocument[]} - The retrieved documents
  */
 const getTransactions = async (userId, type, isProcessed) => {
   let query;
-  if (type == 'borrower') {
+  if (type === 'borrower') {
     query = {borrower: userId};
-  } else {
+  } else if (type === 'lender') {
     query = {lender: userId};
+  } else {
+    query = {$or: [
+      {borrower: userId},
+      {lender: userId},
+    ]};
   }
-  query['processed'] = isProcessed;
+  if (isProcessed === 'true' || isProcessed === 'false') {
+    query['processed'] = isProcessed;
+  }
   const transactions = await Transaction.find(query);
   return transactions;
 };

--- a/server/services/transactions.unit.test.js
+++ b/server/services/transactions.unit.test.js
@@ -62,21 +62,64 @@ describe('services/item', function() {
     });
   });
   describe('getTransactions', function() {
-    it('get transactions by query params', async function() {
+    it('get transactions for borrower and unprocessed', async function() {
       Transaction.findById.mockResolvedValueOnce({'userId': 'xyz'});
       const userId = 'abc123';
       const type = 'borrower';
-      const isProcessed = false;
+      const isProcessed = 'false';
       await transactionServices.getTransactions(userId, type, isProcessed);
       expect(Transaction.find).toHaveBeenCalledWith(
-          {'borrower': userId, 'processed': isProcessed});
+          {[type]: userId, 'processed': isProcessed});
     });
-    it('returns transactions found by the params', async function() {
-      const transaction = new Transaction();
-      const transactions = {transaction, transaction};
-      Transaction.find.mockResolvedValueOnce(transactions);
-      const returned = await transactionServices.getTransactions();
-      expect(returned).toEqual(transactions);
+    it('gets transactions for borrower and processed', async function() {
+      const userId = 'abc123';
+      const type = 'borrower';
+      const isProcessed = 'true';
+      await transactionServices.getTransactions(userId, type, isProcessed);
+      expect(Transaction.find).toHaveBeenCalledWith(
+          {[type]: userId, 'processed': isProcessed});
+    });
+    it('gets transactions for lender and processed', async function() {
+      const userId = 'abc123';
+      const type = 'lender';
+      const isProcessed = 'true';
+      await transactionServices.getTransactions(userId, type, isProcessed);
+      expect(Transaction.find).toHaveBeenCalledWith(
+          {[type]: userId, 'processed': isProcessed});
+    });
+    it('gets transactions for lender and unprocessed', async function() {
+      const userId = 'abc123';
+      const type = 'lender';
+      const isProcessed = 'false';
+      await transactionServices.getTransactions(userId, type, isProcessed);
+      expect(Transaction.find).toHaveBeenCalledWith(
+          {[type]: userId, 'processed': isProcessed});
+    });
+    it('works for both lender/borrower and unprocessed', async function() {
+      const userId = 'abc123';
+      const isProcessed = 'false';
+      await transactionServices.getTransactions(userId, undefined, isProcessed);
+      const expectedQuery = {
+        $or: [
+          {borrower: userId},
+          {lender: userId},
+        ],
+        processed: isProcessed,
+      };
+      expect(Transaction.find).toHaveBeenCalledWith(expectedQuery);
+    });
+    it('works for both lender/borrower and processed', async function() {
+      const userId = 'abc123';
+      const isProcessed = 'true';
+      await transactionServices.getTransactions(userId, undefined, isProcessed);
+      const expectedQuery = {
+        $or: [
+          {borrower: userId},
+          {lender: userId},
+        ],
+        processed: isProcessed,
+      };
+      expect(Transaction.find).toHaveBeenCalledWith(expectedQuery);
     });
   });
 });


### PR DESCRIPTION
A rewrite of the get transactions route for a user to allow a query to get all transaction types as both lender and borrower, since this will be easier to handle on the front-end with a single request

before the `type` and `isProcessed` query was basically, and couldn't get anything beyond what you specified:
`POST /api/transactions/getTransactions?type=borrower&isProcessed=true` (body has the user ID)
after, the queries are optional, and without any queries it will return everything for the user:
`POST /api/transactions/getTransactions` (body has the user ID)