### PR TITLE
Fix codecov erroenous coverage reports (including on master branch)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,12 +22,11 @@ jobs:
         npm run test-server-coverage
       env:
         CI: true
-    - uses: codecov/codecov-action@v1
+    - uses: actions/upload-artifact@v1
+      name: Save client coverage artifact
       with:
-        token: ${{ secrets.CODECOV_TOKEN }} #required
-        flags: server
-        name: codecov-server
-        yml: codecov.yml
+        name: server-coverage
+        path: ./server/coverage/lcov.info
 
   # Testing client
   test-client:
@@ -48,12 +47,45 @@ jobs:
         npm run test-client-coverage
       env:
         CI: true
+    - uses: actions/upload-artifact@v1
+      name: Save client coverage artifact
+      with:
+        name: client-coverage
+        path: ./client/coverage/lcov.info
+
+  # Codecov
+  upload-codecov:
+    needs: [test-client, test-server]
+    runs-on: ubuntu-latest
+    name: Upload to Codecov
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/download-artifact@v1
+      name: Download client coverage
+      with:
+        name: client-coverage
+    - uses: actions/download-artifact@v1
+      name: Download server coverage
+      with:
+        name: server-coverage
     - uses: codecov/codecov-action@v1
+      name: Upload client coverage
       with:
         token: ${{ secrets.CODECOV_TOKEN }} #required
-        flags: client
-        name: codecov-client
-        yml: codecov.yml
+        file: client-coverage/lcov.info #optional
+        flags: client #optional
+        name: codecov-client #optional
+        yml: ./codecov.yml #optional
+        fail_ci_if_error: true #optional (default = false)
+    - uses: codecov/codecov-action@v1
+      name: Upload server coverage
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }} #required
+        file: server-coverage/lcov.info #optional
+        flags: server #optional
+        name: codecov-server #optional
+        yml: ./codecov.yml #optional
+        fail_ci_if_error: true #optional (default = false)
 
   # Linting server
   lint-server:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,7 +23,7 @@ jobs:
       env:
         CI: true
     - uses: actions/upload-artifact@v1
-      name: Save client coverage artifact
+      name: Save server coverage artifact
       with:
         name: server-coverage
         path: ./server/coverage/lcov.info


### PR DESCRIPTION
Codecov is currently broken - I didn't realize this until #147 but there were definitely race conditions going on where Codecov didn't wait for both the server and client reports to be uploaded before having it review the CI and mark it as a pass/fail.  You can see here:

![image](https://user-images.githubusercontent.com/18688793/70629150-81fdfe00-1bf7-11ea-9c79-f6a6559a0f69.png)

It's saying the client coverage failed compared to master with 4.82% less coverage, but this number plus the current coverage (95.18%) equals 100%, and master doesn't have 100% coverage

The the state of master is also currently failed because of erroneous coverage reports - pushing this first before any other should fix all issues with coverage reports in other PRs