### PR TITLE
Add codecov threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,8 @@ coverage:
     project:
       client:
         flags: client
+        threshold: 2
       server:
         flags: server
+        threshold: 2
     patch: false


### PR DESCRIPTION
Codecov is too stringent with checks - so this allows a 2% coverage decrease for the CI to pass