### PR TITLE
Fix comments when not logged in and spacing

### DIFF
--- a/client/src/js/components/Comments/Comment.js
+++ b/client/src/js/components/Comments/Comment.js
@@ -14,7 +14,8 @@ export class Comment extends React.Component {
 		super();
 		this.state = {
 			body: "",
-			rating: 5
+			rating: 5,
+			error: ""
 		};
 	}
 	/** 
@@ -33,20 +34,28 @@ export class Comment extends React.Component {
 	onSubmit = e =>
 	{
 		e.preventDefault();
-		const data = {
-			user: this.props.name,
-			id: this.props.id,
-			product: this.props.prodId,
-			text: this.state.body,
-			rating: this.state.rating
+		if(this.props.auth.isAuthenticated)
+		{
+			const data = {
+				user: this.props.auth.user.name,
+				id: this.props.auth.user.id,
+				product: this.props.prodId,
+				text: this.state.body,
+				rating: this.state.rating
+			}
+			this.props.createComment(data);	
+			window.location.reload(false);	
 		}
-		this.props.createComment(data);	
-		window.location.reload(false);	
+		else
+		{
+			this.setState({ error: "You must be logged in to comment."})
+		}
 	}
 	render()
 	{
 		return(
 			<form noValidate onSubmit={this.onSubmit}>
+				<span>{this.state.error}</span>
 				<Box display="flex">
 					<TextField
 						onChange={this.onChange}
@@ -78,8 +87,7 @@ export class Comment extends React.Component {
 }
 
 const mapStateToProps = state => ({
-	name: state.auth.user.name,
-	id: state.auth.user.id
+	auth: state.auth
 });
 
 export default connect(

--- a/client/src/js/components/Comments/Comment.test.js
+++ b/client/src/js/components/Comments/Comment.test.js
@@ -8,9 +8,19 @@ Enzyme.configure({ adapter: new Adapter() });
 jest.mock('../../actions/comments');
 
 describe('Comment', () => {
+	const params = {
+		auth: {
+			isAuthenticated: true,
+			user: {
+				name: 'Me',
+				id: '123'
+			},
+			loading: false
+		},
+	}
 	let wrapper;
 	beforeEach(() => {
-		wrapper = shallow(<Comment createComment = {createComment} />);
+		wrapper = shallow(<Comment createComment = {createComment} auth = {params.auth} />);
 	});
 
 	test('text entry', () => {
@@ -22,6 +32,17 @@ describe('Comment', () => {
 		window.location.reload = jest.fn();
 		wrapper.find('form').simulate('submit', {preventDefault() {}});
 		expect(wrapper.instance().props.createComment).toHaveBeenCalled();
+	});
+
+	test('error when not logged in', () => {
+		const notAuth = {
+			isAuthenticated: false,
+			user: {},
+			loading: false
+		}
+		wrapper.setProps({ auth: notAuth });
+		wrapper.find('form').simulate('submit', {preventDefault() {}});
+		expect(wrapper.state('error')).toEqual('You must be logged in to comment.');
 	});
 
 	test.skip('rating change', () => {

--- a/client/src/js/components/Comments/CommentList.js
+++ b/client/src/js/components/Comments/CommentList.js
@@ -41,9 +41,9 @@ export class CommentList extends React.Component {
 		const { comments } = this.props;
 		return(
 			<div>
-				<ul>
+				<ul style={{padding: 0}}>
 					{comments.reverse().map(comment => 
-						<Box p={2} key='key'>
+						<Box p={2} key='key' pl={0}>
 							<div style={{display: 'flex', alignItems: 'center' }}>
 								<AccountCircleIcon fontSize="large" />
 								<Link to={{ pathname: `/profile/${comment.id}`}}><Typography variant="h5">{comment.user}</Typography></Link>

--- a/client/src/js/components/Products/ProductDetail.js
+++ b/client/src/js/components/Products/ProductDetail.js
@@ -12,7 +12,7 @@ import green from '@material-ui/core/colors/green'
 const GridCard = styled(Card)`
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr 1fr;
+  grid-template-rows: auto auto 1fr 1fr;
   grid-template-areas:
     "box1 box2"
     "box3 box2";
@@ -32,6 +32,7 @@ const GridDiv = styled.div`
 
 const CommentGrid = styled.div`
   grid-area: box3;
+  margin: 10%;
 `
 
 const SpaceBetween = styled.div`

--- a/client/src/js/components/Products/__snapshots__/ProductDetail.test.js.snap
+++ b/client/src/js/components/Products/__snapshots__/ProductDetail.test.js.snap
@@ -5,7 +5,7 @@ exports[`Product Detail renders 1`] = `
   className="MuiContainer-root MuiContainer-maxWidthLg"
 >
   <div
-    className="MuiPaper-root MuiPaper-elevation1 MuiCard-root sc-bdVaJa jFJDry MuiPaper-rounded"
+    className="MuiPaper-root MuiPaper-elevation1 MuiCard-root sc-bdVaJa gdIaes MuiPaper-rounded"
   >
     <div
       className="MuiCardMedia-root sc-bwzfXH fQtfNt"
@@ -617,12 +617,15 @@ exports[`Product Detail renders 1`] = `
       </div>
     </div>
     <div
-      className="sc-bxivhb gNLXtS"
+      className="sc-bxivhb gMxyjI"
     >
       <form
         noValidate={true}
         onSubmit={[Function]}
       >
+        <span>
+          
+        </span>
         <div
           className="MuiBox-root MuiBox-root-126"
         >


### PR DESCRIPTION
Fixed bug where you could comment without being logged in. This would result in a comment being submitted but there was no username or id associated with it. Now users need to be logged in to comment.
Fixed spacing issue where the height of the grid for list of comments would equal the height of the grid above it causing long blocks of whitespace. Now each grid has its own height specified to prevent this.

![image](https://user-images.githubusercontent.com/43677268/70872939-304bcf80-1f79-11ea-9198-e7d7d1589a88.png)

