### PR TITLE
Fix tiny error causing tests to fail

### DIFF
--- a/client/src/js/actions/products.test.js
+++ b/client/src/js/actions/products.test.js
@@ -156,7 +156,7 @@ describe('actions/products', () => {
         it('dispatches FETCH_TRANSACTIONS.FETCHING', async () => {
             const dispatch = jest.fn()
             mock.mockResolvedValueOnce({})
-            await fetchTransactions()(dispatch);
+            await products.fetchTransactions()(dispatch);
             expect(dispatch).toHaveBeenCalledWith({
                 type: FETCH_TRANSACTIONS.FETCHING
             })


### PR DESCRIPTION
The smallest change that was necessary because I didn't want to see an incredibly long import statement lol.
This is what we sign up for when writing tests regarding a core aspect of our application.